### PR TITLE
Updates to postcss 3

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ var RE_DIRECTIVE = /\* @define ([A-Z][a-zA-Z]+)(?:; (use strict))?\s*/;
  */
 function conformance(options) {
   return function (styles) {
-    var firstNode = styles.rules[0];
+    var firstNode = styles.childs[0];
     var initialComment;
 
     if (firstNode.type !== 'comment') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-bem-linter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A BEM linter for postcss",
   "files": [
     "index.js",
@@ -10,7 +10,7 @@
     "jscs": "^1.6.2",
     "jscs-jsdoc": "0.0.13",
     "mocha": "~1.14.0",
-    "postcss": "^2.2.5"
+    "postcss": "^3.0.2"
   },
   "scripts": {
     "checkstyle": "jscs *.js **/*.js --config=jscs.config.js",


### PR DESCRIPTION
Hello,

PostCSS 3 has been released and appears to deprecate "rules" in favour of "childs" when accessing the Child nodes array.

This will remove the "Property rules has been deprecated and will be removed in 3.1. Use childs instead." deprecation warning which appears when using postcss-bem-linter with PostCSS 3.

Thanks.