### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ var bemLinter = require('postcss-bem-linter');
 
 files.forEach(function (file) {
   var css = fs.readFileSync(file, 'utf-8');
-  postcss().use(bemLinter).process(css);
+  postcss().use(bemLinter()).process(css);
 });
 ```
 


### PR DESCRIPTION
Just added `()` when `bemLinter` is invoked, because otherwise the plugin won't actually run.

In`test.js`, that's how it is invoked: `postcss().use(linter()).process(css);`.

Alternately, `index.js` could be modified to return a function with the parameters `(css, opts)`, as explained here: https://github.com/postcss/postcss#processor --- then `linter` could be invoked without the `()`, I believe.