### PR TITLE
Simplify errors using postcss node.error()

### DIFF
--- a/lib/validate-properties.js
+++ b/lib/validate-properties.js
@@ -21,21 +21,17 @@ function validateCustomProperties(styles, componentName) {
     if (!isValidRule(rule) || rule.selectors[0] !== ':root') { return; }
 
     rule.eachDecl(function (declaration, i) {
-      var column = declaration.source.start.column;
-      var line = declaration.source.start.line;
       var property = declaration.prop;
 
       if (property.indexOf('--') !== 0) {
-        throw new Error(
-          'Invalid property name "' + property + '" near line ' +
-          line + ':' + column + '. ' +
+        throw declaration.error(
+          'Invalid property name "' + property + '". ' +
           'A component\'s `:root` rule must only contain custom properties.'
         );
       }
       if (property.indexOf(componentName + '-') !== 2) {
-        throw new Error(
-          'Invalid custom property name "' + property + '" near line ' +
-          line + ':' + column + '. ' +
+        throw declaration.error(
+          'Invalid custom property name "' + property + '". ' +
           'Custom properties must contain the component name.'
         );
       }

--- a/lib/validate-rules.js
+++ b/lib/validate-rules.js
@@ -17,12 +17,8 @@ module.exports = validateRules;
  */
 function validateRules(styles) {
   styles.eachRule(function (rule) {
-    var column = rule.source.start.column;
-    var line = rule.source.start.line;
-
     if (!isValidRule(rule)) {
-      throw new Error(
-        'Invalid selectors in rule near line ' + line + ':' + column + '. ' +
+      throw rule.error(
         'Cannot combine `:root` with other selectors in a rule.'
       );
     }

--- a/lib/validate-selectors.js
+++ b/lib/validate-selectors.js
@@ -21,16 +21,14 @@ function validateSelectors(styles, componentName, strict) {
     if (rule.parent && rule.parent.name == 'keyframes') {
       return;
     }
-    var column = rule.source.start.column;
-    var line = rule.source.start.line;
     var selectors = rule.selectors;
 
     selectors.forEach(function (selector) {
       // selectors must start with the componentName class, or be `:root`
       if (!isValidSelectorInComponent(selector, componentName, strict)) {
-        throw new Error(
-          'Invalid selector "' + selector + '" near line ' +
-          line + ':' + column + '. ' + 'Please refer to the SUIT CSS naming ' +
+        throw rule.error(
+          'Invalid selector "' + selector + '". ' +
+          'Please refer to the SUIT CSS naming ' +
           'conventions: github.com/suitcss/suit.'
         );
       }


### PR DESCRIPTION
Relates to #1. PostCSS can output errors with line & column & a little display.

Errors end up looking like this:
```
CssSyntaxError: <css input>:4:2: Invalid custom property name "--color". Custom properties must contain the component name.
:root {
	--color: pink;
 ^
}
```