### PR TITLE
Simplify is-valid-rule.js

### DIFF
--- a/lib/is-valid-rule.js
+++ b/lib/is-valid-rule.js
@@ -11,23 +11,6 @@ module.exports = isValidRule;
  */
 
 function isValidRule(rule) {
-  var selectors = rule.selectors;
-
-  if (selectors.length > 1 && containsRoot(selectors)) {
-    return false;
-  }
-
-  function containsRoot(selectors) {
-    var hasRoot = false;
-
-    selectors.forEach(function (selector) {
-      if (selector.indexOf(':root') !== -1) {
-        hasRoot = true;
-      }
-    });
-
-    return hasRoot;
-  }
-
-  return true;
+  var selector = rule.selector;
+  return (selector === ':root' || selector.indexOf(':root') === -1);
 }


### PR DESCRIPTION
Relates to #1. Using the string version of the selector, `rule.selector`, checking for `:root` is more straightforward. (Unless there is some reason this wouldn't always be accurate? --- but mocha tests pass with this change, and I can't think of a situation in which it wouldn't work.)