### PR TITLE
Support pseudos; fixes #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ postcss().use(bemLinter([pattern]));
 
 ### Defining your pattern
 
+Patterns consist of regular expressions that describe valid selector sequences.
+
+Please note that *patterns define sequences, not just simple selectors*. So if, for example,
+you would like to be able to chain state classes to your component classes, as in
+`.Component.is-open`, your pattern needs to allow for this chaining.
+
+Also note that *pseudo-classes and pseudo-elements must be at the end of sequences, and
+will be ignored*. Instead of `.Component:first-child.is-open` you should use
+`.Component.is-open:first-child`. The former will cause an error.
+
 #### Preset Patterns
 
 You can use a preset pattern by passing a string. The following preset patterns are available:

--- a/lib/is-valid-selector.js
+++ b/lib/is-valid-selector.js
@@ -76,11 +76,19 @@ function isValidSelector(selector, componentName, isStrictMode, pattern) {
  * CSS combinators are whitespace, >, +, ~
  * (cf. http://www.w3.org/TR/css3-selectors/#selector-syntax)
  *
+ * Ignore pseudo-selectors ... by presuming they come at the end of the
+ * sequence and cutting them off from the string that gets checked.
+ *
  * @param {String} selector
  * @returns {String[]}
  */
 function listSimpleSelectors(selector) {
-  return selector.split(/[ >\+~]/).filter(function (s) {
-    return s !== ''
-  });
+  return selector
+    .split(/[\s>+~]/)
+    .filter(function (s) {
+      return s !== ''
+    })
+    .map(function (s) {
+      return s.split(':')[0];
+    });
 }

--- a/test/fixtures/patternA-valid-initial.css
+++ b/test/fixtures/patternA-valid-initial.css
@@ -3,4 +3,6 @@
 .f-Foo {}
 .foo-Foo {}
 .foobar-Foo_f {}
-.foobar-Foo_foo {}
+.foobar-Foo_foo
+.foobar-Foo_foo:hover {}
+.foobar-Foo_foo::after {}

--- a/test/fixtures/strict-valid-rules.css
+++ b/test/fixtures/strict-valid-rules.css
@@ -4,10 +4,18 @@
   color: green;
 }
 
+.StrictValidRules:focus {
+  color: green;
+}
+
 .StrictValidRules.is-active {
   color: green;
 }
 
 .StrictValidRules .StrictValidRules--modifier {
+  color: green;
+}
+
+.StrictValidRules .StrictValidRules--modifier::after {
   color: green;
 }

--- a/test/fixtures/valid-rules.css
+++ b/test/fixtures/valid-rules.css
@@ -9,6 +9,11 @@
   color: green;
 }
 
+.ValidRules-child:first-child:hover,
+.ValidRules-child2:nth-child(3)::before {
+  color: green;
+}
+
 .ValidRules.is-active {
   color: green;
 }

--- a/test/selector-validation.js
+++ b/test/selector-validation.js
@@ -43,6 +43,14 @@ describe('selector validation', function () {
       assertSuccess(s('.f-Foo~li>a.link#baz.foo'), patternA);
     });
 
+    it('ignores pseudo-selectors at the end of a sequence', function () {
+      var s = selectorTester('/** @define Foo */');
+
+      assertSuccess(s('.f-Foo:hover'), patternA);
+      assertSuccess(s('.f-Foo::before'), patternA);
+      assertSuccess(s('.f-Foo:not(\'.is-open\')'), patternA);
+    });
+
     describe('in strict mode', function () {
       var s = selectorTester('/** @define Foo; use strict */');
 


### PR DESCRIPTION
The caveat here is that I'm assuming users will put (or *want* to put) pseudo-classes and -elements at the *end* of sequences, instead of in the middle. I don't think that's an unreasonable assumption, do you?