### PR TITLE
Tidy up terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 A [PostCSS](https://github.com/postcss/postcss) plugin to lint *BEM-style* CSS.
 
 *BEM-style* describes CSS that follows a more-or-less strict set of conventions determining
-what selectors can be used. Typically, these conventions require that classes be namespaced
-according to the component (or "block") that contains them, and that all characters after the
+what selectors can be used. Typically, these conventions require that classes begin with
+the name of the component (or "block") that contains them, and that all characters after the
 namespace follow a specified pattern. Original BEM methodology refers to "blocks", "elements",
 and "modifiers"; SUIT refers to "components", "descendants", and "modifiers". You might have your
 own terms for similar concepts.
@@ -25,7 +25,8 @@ npm install postcss-bem-linter
 
 **Default mode**:
 
-* Only allow selectors that *begin* with a selector sequence matching the defined convention.
+* Only allow selectors that *begin* with a selector sequence matching the defined convention
+  (ignoring sequences are combinators).
 * Only allow custom-property names that *begin* with the defined `ComponentName`.
 * The `:root` selector can only contain custom-properties.
 * The `:root` cannot be combined with other selectors.
@@ -33,9 +34,9 @@ npm install postcss-bem-linter
 **Strict mode**:
 
 * All the tests in "default mode".
-* Disallow selectors that contain chained selector sequences that do not match the
-  defined convention. (The convention for chained sequences can be the same as or different from
-  that for initial sequences.)
+* Disallow selector sequences *after combinators* that do not match the
+  defined convention. (The convention for sequences after combinators can be the same as
+  or different from that for initial sequences.)
 
 ## Use
 
@@ -73,14 +74,14 @@ You can define a custom pattern by passing an object with the following properti
   Default is `/[-_a-zA-Z0-9]+/`.
 - `selectors`: Either of the following:
   - A single function that accepts a component name and returns a regular expression describing
-    all valid selectors.
-  - An object consisting of two methods, `initial` and `chainable`. Both methods accept a
+    all valid selector sequences.
+  - An object consisting of two methods, `initial` and `combined`. Both methods accept a
     component name and return a regular expression. `initial` returns a description of valid
-    initial selector sequences — those occurring at the beginning of a selector. `chainable` returns
-    a description of valid chainable selector sequences — those occurring after the first sequence.
-    Two things to note: In non-strict mode, *any* chained sequences are accepted.
-    And if you do not specify a chainable pattern, in strict mode it is assumed that chained
-    selectors must match the same pattern as initial selectors.
+    initial selector sequences — those occurring at the beginning of a selector, before any
+    combinators. `combined` returns a description of valid selector sequences allowed *after* combinators.
+    Two things to note: In non-strict mode, *any* combined sequences are accepted.
+    And if you do not specify a combined pattern, in strict mode it is assumed that combined
+    sequences must match the same pattern as initial sequences.
 
 So you might call the plugin in any of the following ways:
 
@@ -97,22 +98,22 @@ bemLinter({
   componentName: /[A-Z]+/
 });
 
-// define a single RegExp for all selector sequences, initial or chained
+// define a single RegExp for all selector sequences, initial or combined
 bemLinter({
   selectors: function(componentName) {
     return new RegExp('^\\.' + componentName + '(?:-[a-z]+)?$');
   }
 });
 
-// define separate `componentName`, `initial`, and `chainable` RegExps
+// define separate `componentName`, `initial`, and `combined` RegExps
 bemLinter({
   componentName: /[A-Z]+/,
   selectors: {
     initial: function(componentName) {
       return new RegExp('^\\.' + componentName + '(?:-[a-z]+)?$');
     },
-    chainable: function(componentName) {
-      return new RegExp('^\\.chained-' + componentName + '-[a-z]+$');
+    combined: function(componentName) {
+      return new RegExp('^\\.combined-' + componentName + '-[a-z]+$');
     }
   }
 });

--- a/lib/is-valid-selector.js
+++ b/lib/is-valid-selector.js
@@ -7,7 +7,7 @@
 module.exports = isValidSelector;
 
 /**
- * A SelectorPattern defines acceptable patterns for selectors
+ * A SelectorPattern defines acceptable patterns for selector sequences
  * in component stylesheets.
  *
  * `selector-patterns.js` contains pre-defined
@@ -23,12 +23,12 @@ module.exports = isValidSelector;
  * - An object that has the following properties:
  *   - initial: A function that accepts a component name and returns
  *   	 a regexp. This regexp will be used to test selector sequences
- *   	 at the beginning of the selector. If no chainable property is
- *   	 included, this function will also be used to test chained
- *   	 sequences.
- *   - chainable: A function that accepts a component name and returns
+ *   	 at the beginning of the selector (before any combinators).
+ *   	 If no combined property is included, this function will also
+ *   	 be used to test sequences after combinators.
+ *   - combined: A function that accepts a component name and returns
  *   	 a regexp. This regexp will be used to test selector sequences
- *   	 that are chained (not the first one), if they do not already
+ *   	 that come after combinators, if they do not already
  *   	 match the initial pattern.
  */
 
@@ -49,20 +49,20 @@ function isValidSelector(selector, componentName, isStrictMode, pattern) {
   var initialPattern = (pattern.initial) ?
     pattern.initial(componentName) :
     pattern(componentName);
-  var chainablePattern = (pattern.chainable) ?
-    pattern.chainable(componentName) :
+  var combinedPattern = (pattern.combined) ?
+    pattern.combined(componentName) :
     initialPattern;
-  var simpleSelectors = listSimpleSelectors(selector);
+  var sequences = listSequences(selector);
 
   // Error if an acceptable initialPattern does not begin the selector
-  if (!initialPattern.test(simpleSelectors[0])) { return false; }
+  if (!initialPattern.test(sequences[0])) { return false; }
 
-  // In strict mode, error if chained simple selectors do not match the
-  // chainablePattern
+  // In strict mode, error if combined simple selectors do not match the
+  // combinedPattern
   if (isStrictMode) {
-    return simpleSelectors.slice(1).every(function (chainedSelector) {
-      return initialPattern.test(chainedSelector) ||
-      chainablePattern.test(chainedSelector);
+    return sequences.slice(1).every(function (combinedSequence) {
+      return initialPattern.test(combinedSequence) ||
+      combinedPattern.test(combinedSequence);
     });
   }
 
@@ -70,8 +70,8 @@ function isValidSelector(selector, componentName, isStrictMode, pattern) {
 }
 
 /**
- * Extract an array of simple selectors from a selector string ---
- * all the selectors that were chained with combinators.
+ * Extract an array of selector sequences from a selector string ---
+ * all the sequences that were combined via combinators.
  *
  * CSS combinators are whitespace, >, +, ~
  * (cf. http://www.w3.org/TR/css3-selectors/#selector-syntax)
@@ -82,11 +82,11 @@ function isValidSelector(selector, componentName, isStrictMode, pattern) {
  * @param {String} selector
  * @returns {String[]}
  */
-function listSimpleSelectors(selector) {
+function listSequences(selector) {
   return selector
     .split(/[\s>+~]/)
     .filter(function (s) {
-      return s !== ''
+      return s !== '';
     })
     .map(function (s) {
       return s.split(':')[0];

--- a/test/selector-validation.js
+++ b/test/selector-validation.js
@@ -34,7 +34,7 @@ describe('selector validation', function () {
       assertFailure('/** @define Foo */ .Foo {}', patternA);
     });
 
-    it('accepts any chained selectors in non-strict mode', function () {
+    it('accepts any combined selectors in non-strict mode', function () {
       var s = selectorTester('/** @define Foo */');
 
       assertSuccess(s('.f-Foo .f-Foo'), patternA);
@@ -54,12 +54,12 @@ describe('selector validation', function () {
     describe('in strict mode', function () {
       var s = selectorTester('/** @define Foo; use strict */');
 
-      it('accepts valid chained selectors', function () {
+      it('accepts valid combined selectors', function () {
         assertSuccess(s('.f-Foo .f-Foo'), patternA);
         assertSuccess(s('.f-Foo > .f-Foo'), patternA);
       });
 
-      it('rejects invalid chained selectors', function () {
+      it('rejects invalid combined selectors', function () {
         assertFailure(s('.f-Foo > div'), patternA);
         assertFailure(s('.f-Foo + #baz'), patternA);
         assertFailure(s('.f-Foo~li>a.link#baz.foo'), patternA);
@@ -68,20 +68,20 @@ describe('selector validation', function () {
   });
 
   describe(
-    'with different `initial` and `chainable` selector patterns',
+    'with different `initial` and `combined` selector patterns',
     function () {
     var patternB = {
       selectors: {
         initial: function (cmpt) {
           return new RegExp('^\\.' + cmpt + '(?:-[a-z]+)?$');
         },
-        chainable: function (cmpt) {
+        combined: function (cmpt) {
           return new RegExp('^\\.c-' + cmpt + '(?:-[a-z]+)?$');
         }
       }
     };
 
-    it('accepts any chained selectors in non-strict mode', function () {
+    it('accepts any combined selectors in non-strict mode', function () {
       var s = selectorTester('/** @define Foo */');
 
       assertSuccess(s('.Foo .c-Foo'), patternB);
@@ -94,13 +94,13 @@ describe('selector validation', function () {
     describe('in strict mode', function () {
       var s = selectorTester('/** @define Foo; use strict */');
 
-      it('accepts valid chained selectors', function () {
+      it('accepts valid combined selectors', function () {
         assertSuccess(s('.Foo .c-Foo'), patternB);
         assertSuccess(s('.Foo-bar > .c-Foo-bar'), patternB);
         assertSuccess(s('.Foo-bar>.c-Foo-bar'), patternB);
       });
 
-      it('rejects invalid chained selectors', function () {
+      it('rejects invalid combined selectors', function () {
         assertFailure(s('.Foo .cc-Foo'), patternB);
         assertFailure(s('.Foo > .Foo-F'), patternB);
       });


### PR DESCRIPTION
To make sure everybody knows what they're getting in to I tried to make the terms a little more precise. The spec says that "sequences" are "chains" of "simple selectors"; so instead of using "chainable" as I did before I used "combined". So that's the main change. I also tried to be nitpicky about the distinction between "selectors" and "sequences". 