### PR TITLE
Add options param and SUIT namespace as use-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,15 @@ npm install postcss-bem-linter
 ## Use
 
 ```
-postcss().use(bemLinter([pattern]));
+postcss().use(bemLinter([pattern, options]));
 ```
 
 ### Defining your pattern
 
-Patterns consist of regular expressions that describe valid selector sequences.
+Patterns consist of regular expressions, and functions that return regular expressions,
+which describe valid selector sequences.
 
-Please note that *patterns define sequences, not just simple selectors*. So if, for example,
+Please note that *patterns describe sequences, not just simple selectors*. So if, for example,
 you would like to be able to chain state classes to your component classes, as in
 `.Component.is-open`, your pattern needs to allow for this chaining.
 
@@ -58,9 +59,15 @@ will be ignored*. Instead of `.Component:first-child.is-open` you should use
 
 #### Preset Patterns
 
-You can use a preset pattern by passing a string. The following preset patterns are available:
+You can use a preset pattern by passing a string as the `pattern`, and, if needed, an `options` object,
+as in `bemLinter('suit', { namespace: 'twt' })`. Options are pattern-specific.
+
+The following preset patterns are available:
 
 - `'suit'` (default), as defined [here](https://github.com/suitcss/suit/blob/master/doc/naming-conventions.md).
+  Options:
+  - `namespace`: a namespace to prefix valid classes, as described
+    [in the SUIT docs](https://github.com/suitcss/suit/blob/master/doc/naming-conventions.md#namespace-optional)
 - `'bem'`, as defined [here](https://en.bem.info/tools/bem/bem-naming/).
 
 **`'suit'` is the default pattern**; so if you do not pass any `pattern` argument,
@@ -91,6 +98,7 @@ So you might call the plugin in any of the following ways:
 // use 'suit' conventions
 bemLinter();
 bemLinter('suit');
+bemLinter('suit', { namespace: 'twt' });
 
 // use 'bem' conventions
 bemLinter('bem');

--- a/index.js
+++ b/index.js
@@ -29,8 +29,10 @@ var UTILITIES_IDENT = 'utilities';
  * @param {RegExp} [patterns.componentName]
  * @param {RegExp} [patterns.utilities]
  * @param {Object|Function} [patterns.selectors]
+ * @param {Object} [opts] - Options that are can be used by
+ *   a pattern (e.g. `namespace`)
  */
-function conformance(patterns) {
+function conformance(patterns, opts) {
   patterns = patterns || 'suit';
   if (typeof patterns === 'string') {
     patterns = presetPatterns[patterns];
@@ -52,7 +54,6 @@ function conformance(patterns) {
         initialComment + '*/.',
         'Component names must match the pattern ' + componentNamePattern
       );
-      return;
     }
 
     var isStrict = initialComment.match(RE_DIRECTIVE)[2] === 'use strict';
@@ -61,7 +62,9 @@ function conformance(patterns) {
     if (isUtilities) {
       validateUtilities(styles, patterns.utilities);
     } else {
-      validateSelectors(styles, defined, isStrict, patterns.selectors);
+      validateSelectors(
+        styles, defined, isStrict, patterns.selectors, opts
+      );
     }
     validateCustomProperties(styles, defined);
   };

--- a/lib/is-valid-selector.js
+++ b/lib/is-valid-selector.js
@@ -39,18 +39,19 @@ module.exports = isValidSelector;
  * @param {String|SelectorPattern} [pattern="suit"] - Either a string
  *   identifying a pre-defined SelectorPattern to use, or a custom
  *   SelectorPattern, as described above
+ * @param {Object} [opts] - Options to pass to the pattern functions
  * @returns {Boolean}
  */
-function isValidSelector(selector, componentName, isStrictMode, pattern) {
+function isValidSelector(selector, componentName, isStrictMode, pattern, opts) {
 
   // Don't bother with :root
   if (selector === ':root') { return true; }
 
   var initialPattern = (pattern.initial) ?
-    pattern.initial(componentName) :
-    pattern(componentName);
+    pattern.initial(componentName, opts) :
+    pattern(componentName, opts);
   var combinedPattern = (pattern.combined) ?
-    pattern.combined(componentName) :
+    pattern.combined(componentName, opts) :
     initialPattern;
   var sequences = listSequences(selector);
 

--- a/lib/preset-patterns.js
+++ b/lib/preset-patterns.js
@@ -18,14 +18,17 @@ module.exports = {
 
 /**
  * @param {String} componentName
+ * @param {Object} [opts]
+ * @param {String} [opts.namespace]
  * @returns {RegExp}
  */
-function suitSelector(componentName) {
-  var OPTIONAL_PART =  '(?:-[a-zA-Z0-9]+)?';
+function suitSelector(componentName, opts) {
+  var ns = (opts && opts.namespace) ? opts.namespace + '-' : '';
+  var OPTIONAL_PART = '(?:-[a-zA-Z0-9]+)?';
   var OPTIONAL_MODIFIER = '(?:--[a-zA-Z0-9]+)?';
   var OPTIONAL_STATE = '(?:\\.is-[a-zA-Z0-9]+)?';
   var OPTIONAL = OPTIONAL_PART + OPTIONAL_MODIFIER + OPTIONAL_STATE;
-  return new RegExp('^\\.' + componentName + '\\b' + OPTIONAL + '$');
+  return new RegExp('^\\.' + ns + componentName + '\\b' + OPTIONAL + '$');
 }
 
 /**

--- a/lib/validate-selectors.js
+++ b/lib/validate-selectors.js
@@ -15,8 +15,11 @@ module.exports = validateSelectors;
 /**
  * @param {Object} styles
  * @param {String} componentName
+ * @param {Boolean} strict
+ * @param {Object} pattern
+ * @param {Object} [opts]
  */
-function validateSelectors(styles, componentName, strict, pattern) {
+function validateSelectors(styles, componentName, strict, pattern, opts) {
   styles.eachRule(function (rule) {
     if (rule.parent && rule.parent.name == 'keyframes') {
       return;
@@ -25,7 +28,7 @@ function validateSelectors(styles, componentName, strict, pattern) {
 
     selectors.forEach(function (selector) {
       // selectors must start with the componentName class, or be `:root`
-      if (!isValid(selector, componentName, strict, pattern)) {
+      if (!isValid(selector, componentName, strict, pattern, opts)) {
         throw rule.error('Invalid selector "' + selector + '". ');
       }
     });

--- a/test/suit-pattern.js
+++ b/test/suit-pattern.js
@@ -1,6 +1,7 @@
 var util = require('./test-util');
 var assertSuccess = util.assertSuccess;
 var assertFailure = util.assertFailure;
+var selectorTester = util.selectorTester;
 var fixture = util.fixture;
 
 describe('using SUIT pattern (default)', function () {
@@ -30,6 +31,14 @@ describe('using SUIT pattern (default)', function () {
     assertSuccess(s('.u-fooBar17'));
     assertFailure(s('.Foo'));
     assertFailure(s('.u-Foo'));
+  });
+
+  it('understands namespaces', function () {
+    var s = selectorTester('/** @define Foo */');
+
+    assertSuccess(s('.ns-Foo'), 'suit', { namespace: 'ns' });
+    assertFailure(s('.Foo'), 'suit', { namespace: 'ns' });
+    assertSuccess(s('.Ho04__d-Foo'), 'suit', { namespace: 'Ho04__d' });
   });
 
   describe('in strict mode', function () {

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -3,24 +3,24 @@ var linter = require('..');
 var fs = require('fs');
 var postcss = require('postcss');
 
-function processCss(css, opts) {
-  return postcss().use(linter(opts)).process(css);
+function processCss(css, pattern, opts) {
+  return postcss().use(linter(pattern, opts)).process(css);
 }
 
 function fixture(name) {
   return fs.readFileSync('test/fixtures/' + name + '.css', 'utf8').trim();
 }
 
-function assertSuccess(css, opts) {
+function assertSuccess(css, pattern, opts) {
   var result = function () {
-    processCss(css, opts);
+    processCss(css, pattern, opts);
   };
   assert.doesNotThrow(result);
 }
 
-function assertFailure(css, opts) {
+function assertFailure(css, pattern, opts) {
   var result = function () {
-    processCss(css, opts);
+    processCss(css, pattern, opts);
   };
   assert.throws(result);
 }


### PR DESCRIPTION
The options are passed to pattern functions, to be used by them in creating regular expressions. This means that the options object is open-ended, determined by specific patterns rather than by the plugin.

The addition of a namespace option to the SUIT pattern serves as example of how options can be used by patterns, and fixes https://github.com/necolas/postcss-bem-linter/issues/14. 

I will push another commit in a second to add some docs for the change.