### PR TITLE
Terminology: componentSelectors and utilitySelectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A [PostCSS](https://github.com/postcss/postcss) plugin to lint *BEM-style* CSS.
 *BEM-style* describes CSS that follows a more-or-less strict set of conventions determining
 what selectors can be used. Typically, these conventions require that classes begin with
 the name of the component (or "block") that contains them, and that all characters after the
-namespace follow a specified pattern. Original BEM methodology refers to "blocks", "elements",
+component name follow a specified pattern. Original BEM methodology refers to "blocks", "elements",
 and "modifiers"; SUIT refers to "components", "descendants", and "modifiers". You might have your
 own terms for similar concepts.
 
@@ -48,7 +48,7 @@ which describe valid selector sequences.
 
 Please note that *patterns describe sequences, not just simple selectors*. So if, for example,
 you would like to be able to chain state classes to your component classes, as in
-`.Component.is-open`, your pattern needs to allow for this chaining.
+`.Component.is-open`, your regular expression needs to allow for this chaining.
 
 Also note that *pseudo-classes and pseudo-elements must be at the end of sequences, and
 will be ignored*. Instead of `.Component:first-child.is-open` you should use
@@ -76,9 +76,9 @@ You can define a custom pattern by passing an object with the following properti
 
 - `componentName` (optional): A regular expression describing valid component names.
   Default is `/[-_a-zA-Z0-9]+/`.
-- `selectors`: Either of the following:
+- `componentSelectors`: Either of the following:
   - A single function that accepts a component name and returns a regular expression describing
-    all valid selector sequences.
+    all valid selector sequences for the stylesheet.
   - An object consisting of two methods, `initial` and `combined`. Both methods accept a
     component name and return a regular expression. `initial` returns a description of valid
     initial selector sequences — those occurring at the beginning of a selector, before any
@@ -86,7 +86,7 @@ You can define a custom pattern by passing an object with the following properti
     Two things to note: If you do not specify a combined pattern, it is assumed that combined
     sequences must match the same pattern as initial sequences.
     And in weak mode, *any* combined sequences are accepted.
-- `utilities`: A regular expression describing valid utility selectors. This will be use
+- `utilitySelectors`: A regular expression describing valid utility selectors. This will be use
   if the stylesheet uses `/** @define utilities */`, as explained below.
 
 So you might call the plugin in any of the following ways:
@@ -107,7 +107,7 @@ bemLinter({
 
 // define a single RegExp for all selector sequences, initial or combined
 bemLinter({
-  selectors: function(componentName) {
+  componentSelectors: function(componentName) {
     return new RegExp('^\\.' + componentName + '(?:-[a-z]+)?$');
   }
 });
@@ -115,7 +115,7 @@ bemLinter({
 // define separate `componentName`, `initial`, `combined`, and `utilities` RegExps
 bemLinter({
   componentName: /[A-Z]+/,
-  selectors: {
+  componentSelectors: {
     initial: function(componentName) {
       return new RegExp('^\\.' + componentName + '(?:-[a-z]+)?$');
     },
@@ -123,7 +123,7 @@ bemLinter({
       return new RegExp('^\\.combined-' + componentName + '-[a-z]+$');
     }
   },
-  utilities: /^\.util-[a-z]+$/
+  utilitySelectors: /^\.util-[a-z]+$/
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -27,8 +27,8 @@ var UTILITIES_IDENT = 'utilities';
  *
  * @param {Object} [patterns = 'suit']
  * @param {RegExp} [patterns.componentName]
- * @param {RegExp} [patterns.utilities]
- * @param {Object|Function} [patterns.selectors]
+ * @param {RegExp} [patterns.utilitySelectors]
+ * @param {Object|Function} [patterns.componentSelectors]
  * @param {Object} [opts] - Options that are can be used by
  *   a pattern (e.g. `namespace`)
  */
@@ -60,10 +60,10 @@ function conformance(patterns, opts) {
 
     validateRules(styles);
     if (isUtilities) {
-      validateUtilities(styles, patterns.utilities);
+      validateUtilities(styles, patterns.utilitySelectors);
     } else {
       validateSelectors(
-        styles, defined, weakMode, patterns.selectors, opts
+        styles, defined, weakMode, patterns.componentSelectors, opts
       );
     }
     validateCustomProperties(styles, defined);

--- a/lib/preset-patterns.js
+++ b/lib/preset-patterns.js
@@ -7,12 +7,12 @@
 module.exports = {
   suit: {
     componentName: /[A-Z][a-zA-Z]+/,
-    selectors: suitSelector,
-    utilities: /^\.u(?:-[a-z][a-zA-Z0-9]+)+$/
+    componentSelectors: suitSelector,
+    utilitySelectors: /^\.u(?:-[a-z][a-zA-Z0-9]+)+$/
   },
   bem: {
     componentName: /[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*/,
-    selectors: bemSelector
+    componentSelectors: bemSelector
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lib"
   ],
   "devDependencies": {
-    "jscs": "^1.11.0",
+    "jscs": "1.11.3",
     "jscs-jsdoc": "^0.4.0",
     "mocha": "^2.0.0",
     "postcss": "^4.0.0"

--- a/test/selector-validation.js
+++ b/test/selector-validation.js
@@ -5,8 +5,8 @@ var selectorTester = util.selectorTester;
 
 describe('selector validation', function () {
   describe('with a custom `componentName` pattern', function () {
-    var p1 = { componentName: /^[A-Z]+$/, selectors: function () { return /.*/; } };
-    var p2 = { componentName: /^[a-z]+1$/, selectors: function () { return /.*/; } };
+    var p1 = { componentName: /^[A-Z]+$/, componentSelectors: function () { return /.*/; } };
+    var p2 = { componentName: /^[a-z]+1$/, componentSelectors: function () { return /.*/; } };
 
     it('rejects invalid component names', function () {
       assertFailure('/** @define Foo */', p1);
@@ -19,25 +19,28 @@ describe('selector validation', function () {
     });
   });
 
-  describe('with a single `selectors` pattern', function () {
+  describe('with a single `componentSelectors` pattern', function () {
     var patternA = {
-      selectors: function (cmpt) {
+      componentSelectors: function (cmpt) {
         return new RegExp('^\\.[a-z]+-' + cmpt + '(?:_[a-z]+)?$');
       }
     };
     var s = selectorTester('/** @define Foo */');
 
-    it('accepts valid initial selectors', function () {
+    it('accepts valid initial componentSelectors', function () {
       assertSuccess(util.fixture('patternA-valid'), patternA);
     });
 
-    it('rejects invalid initial selectors', function () {
+    it('rejects invalid initial componentSelectors', function () {
       assertFailure(s('.Foo'), patternA);
     });
 
-    it('rejects invalid initial selectors in media queries', function () {
-      assertFailure('/** @define Foo */ @media all { .Bar {} }');
-    });
+    it(
+      'rejects invalid initial componentSelectors in media queries',
+      function () {
+        assertFailure('/** @define Foo */ @media all { .Bar {} }');
+      }
+    );
 
     it('ignores pseudo-selectors at the end of a sequence', function () {
       assertSuccess(s('.f-Foo:hover'), patternA);
@@ -45,12 +48,12 @@ describe('selector validation', function () {
       assertSuccess(s('.f-Foo:not(\'.is-open\')'), patternA);
     });
 
-    it('accepts valid combined selectors', function () {
+    it('accepts valid combined componentSelectors', function () {
       assertSuccess(s('.f-Foo .f-Foo'), patternA);
       assertSuccess(s('.f-Foo > .f-Foo'), patternA);
     });
 
-    it('rejects invalid combined selectors', function () {
+    it('rejects invalid combined componentSelectors', function () {
       assertFailure(s('.f-Foo > div'), patternA);
       assertFailure(s('.f-Foo + #baz'), patternA);
       assertFailure(s('.f-Foo~li>a.link#baz.foo'), patternA);
@@ -59,7 +62,7 @@ describe('selector validation', function () {
     describe('in weak mode', function () {
       var sWeak = selectorTester('/** @define Foo; weak */');
 
-      it('accepts any combined selectors', function () {
+      it('accepts any combined componentSelectors', function () {
         assertSuccess(sWeak('.f-Foo .f-Foo'), patternA);
         assertSuccess(sWeak('.f-Foo > div'), patternA);
         assertSuccess(sWeak('.f-Foo + #baz'), patternA);
@@ -72,7 +75,7 @@ describe('selector validation', function () {
     'with different `initial` and `combined` selector patterns',
     function () {
     var patternB = {
-      selectors: {
+      componentSelectors: {
         initial: function (cmpt) {
           return new RegExp('^\\.' + cmpt + '(?:-[a-z]+)?$');
         },
@@ -83,13 +86,13 @@ describe('selector validation', function () {
     };
     var s = selectorTester('/** @define Foo */');
 
-    it('accepts valid combined selectors', function () {
+    it('accepts valid combined componentSelectors', function () {
       assertSuccess(s('.Foo .c-Foo'), patternB);
       assertSuccess(s('.Foo-bar > .c-Foo-bar'), patternB);
       assertSuccess(s('.Foo-bar>.c-Foo-bar'), patternB);
     });
 
-    it('rejects invalid combined selectors', function () {
+    it('rejects invalid combined componentSelectors', function () {
       assertFailure(s('.Foo .cc-Foo'), patternB);
       assertFailure(s('.Foo > .Foo-F'), patternB);
     });
@@ -97,7 +100,7 @@ describe('selector validation', function () {
     describe('in weak mode', function () {
       var sWeak = selectorTester('/** @define Foo; weak*/');
 
-      it('accepts any combined selectors', function () {
+      it('accepts any combined componentSelectors', function () {
         assertSuccess(sWeak('.Foo .c-Foo'), patternB);
         assertSuccess(sWeak('.Foo .Foo'), patternB);
         assertSuccess(sWeak('.Foo > div'), patternB);
@@ -107,18 +110,18 @@ describe('selector validation', function () {
     });
   });
 
-  describe('checking utility classes', function () {
+  describe('checking utilitySelectors', function () {
     var patternC = {
-      utilities: /^\.UTIL-[a-z]+$/
+      utilitySelectors: /^\.UTIL-[a-z]+$/
     };
     var s = selectorTester('/** @define utilities */');
 
-    it('accepts valid utility selectors', function () {
+    it('accepts valid utilitySelectors', function () {
       assertSuccess(s('.UTIL-foo'), patternC);
       assertSuccess(s('.UTIL-foobarbaz'), patternC);
     });
 
-    it('rejects invalid utility selectors', function () {
+    it('rejects invalid utilitySelectors', function () {
       assertFailure(s('.Foo'), patternC);
       assertFailure(s('.U-foo'), patternC);
     });


### PR DESCRIPTION
Addresses #22.

Changes the names of properties in the `pattern` parameter so we have `componentSelectors` and `utilitySelectors`. That was the clearest way that I could think of to name these things.