### PR TITLE
Postcss 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "0.12"
+  - "iojs"

--- a/lib/validate-properties.js
+++ b/lib/validate-properties.js
@@ -15,8 +15,9 @@ module.exports = validateCustomProperties;
 /**
  * @param {Object} styles
  * @param {String} componentName
+ * @param {Result} result - PostCSS Result, for registering warnings
  */
-function validateCustomProperties(styles, componentName) {
+function validateCustomProperties(styles, componentName, result) {
   styles.eachRule(function (rule) {
     if (!isValidRule(rule) || rule.selectors[0] !== ':root') { return; }
 
@@ -24,15 +25,17 @@ function validateCustomProperties(styles, componentName) {
       var property = declaration.prop;
 
       if (property.indexOf('--') !== 0) {
-        throw declaration.error(
-          'Invalid property name "' + property + '". ' +
-          'A component\'s `:root` rule must only contain custom properties.'
+        result.warn(
+          'Invalid custom property name "' + property + '": ' +
+          '`:root` rules must only contain custom properties',
+          { node: declaration }
         );
-      }
-      if (property.indexOf(componentName + '-') !== 2) {
-        throw declaration.error(
-          'Invalid custom property name "' + property + '". ' +
-          'Custom properties must contain the component name.'
+      } else if (property.indexOf(componentName + '-') !== 2) {
+        result.warn(
+          'Invalid custom property name "' + property + '": ' +
+          'a component\'s custom properties must start with the ' +
+          'component name',
+          { node: declaration }
         );
       }
     });

--- a/lib/validate-rules.js
+++ b/lib/validate-rules.js
@@ -14,12 +14,14 @@ module.exports = validateRules;
 
 /**
  * @param {Object} styles
+ * @param {Result} result - PostCSS Result, for registering warnings
  */
-function validateRules(styles) {
+function validateRules(styles, result) {
   styles.eachRule(function (rule) {
     if (!isValidRule(rule)) {
-      throw rule.error(
-        'Cannot combine `:root` with other selectors in a rule.'
+      result.warn(
+        'Cannot combine `:root` with other selectors in a rule',
+        { node: rule }
       );
     }
   });

--- a/lib/validate-selectors.js
+++ b/lib/validate-selectors.js
@@ -17,9 +17,12 @@ module.exports = validateSelectors;
  * @param {String} componentName
  * @param {Boolean} weakMode
  * @param {Object} pattern
- * @param {Object} [opts]
+ * @param {Object} opts
+ * @param {Result} result - PostCSS Result, for registering warnings
  */
-function validateSelectors(styles, componentName, weakMode, pattern, opts) {
+function validateSelectors(
+  styles, componentName, weakMode, pattern, opts, result
+) {
   styles.eachRule(function (rule) {
     if (rule.parent && rule.parent.name == 'keyframes') {
       return;
@@ -29,7 +32,10 @@ function validateSelectors(styles, componentName, weakMode, pattern, opts) {
     selectors.forEach(function (selector) {
       // selectors must start with the componentName class, or be `:root`
       if (!isValid(selector, componentName, weakMode, pattern, opts)) {
-        throw rule.error('Invalid selector "' + selector + '". ');
+        result.warn(
+          'Invalid component selector "' + selector + '"',
+          { node: rule }
+        );
       }
     });
   });

--- a/lib/validate-utilities.js
+++ b/lib/validate-utilities.js
@@ -15,14 +15,15 @@ module.exports = validateSelectors;
 /**
  * @param {Object} styles
  * @param {RegExp} pattern
+ * @param {Result} result - PostCSS Result, for registering warnings
  */
-function validateSelectors(styles, pattern) {
+function validateSelectors(styles, pattern, result) {
   styles.eachRule(function (rule) {
     rule.selectors.forEach(function (selector) {
       if (!isValid(selector, pattern)) {
-        throw rule.error(
-          'Invalid selector "' + selector +
-          '": does not match the utility class convention.'
+        result.warn(
+          'Invalid utility selector "' + selector + '"',
+          { node: rule }
         );
       }
     });

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "postcss": "^4.1.0"
   },
   "devDependencies": {
-    "jscs": "1.11.3",
-    "jscs-jsdoc": "0.4.5",
-    "mocha": "2.2.1"
+    "jscs": "1.12.0",
+    "jscs-jsdoc": "0.4.6",
+    "mocha": "2.2.3"
   },
   "scripts": {
     "checkstyle": "jscs *.js **/*.js --config=jscs.config.js",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
     "index.js",
     "lib"
   ],
+  "dependencies": {
+    "postcss": "^4.1.0"
+  },
   "devDependencies": {
     "jscs": "1.11.3",
     "jscs-jsdoc": "0.4.5",
-    "mocha": "2.2.1",
-    "postcss": "4.0.0"
+    "mocha": "2.2.1"
   },
   "scripts": {
     "checkstyle": "jscs *.js **/*.js --config=jscs.config.js",

--- a/test/bem-pattern.js
+++ b/test/bem-pattern.js
@@ -1,9 +1,9 @@
 var util = require('./test-util');
-var assertFailure = util.assertFailure;
+var assertSingleFailure = util.assertSingleFailure;
 
 describe('using BEM pattern', function () {
-  it('accepts valid selectors', function () {
-    util.assertSuccess(util.fixture('bem-valid'), 'bem');
+  it('accepts valid selectors', function (done) {
+    util.assertSuccess(done, util.fixture('bem-valid'), 'bem');
   });
 
   describe('when given invalid selectors', function () {
@@ -11,36 +11,42 @@ describe('using BEM pattern', function () {
 
     // mirroring tests from
     // https://github.com/bem/bem-naming/blob/master/test/original/validate.test.js
-    it('should not validate elem without block', function () {
-      assertFailure(s('__elem'), 'bem');
+    it('should not validate elem without block', function (done) {
+      assertSingleFailure(done, s('__elem'), 'bem');
     });
 
-    it('should not validate boolean mod without block', function () {
-      assertFailure(s('_mod'), 'bem');
+    it('should not validate boolean mod without block', function (done) {
+      assertSingleFailure(done, s('_mod'), 'bem');
     });
 
-    it('should not validate mod without block', function () {
-      assertFailure(s('_mod_val'), 'bem');
+    it('should not validate mod without block', function (done) {
+      assertSingleFailure(done, s('_mod_val'), 'bem');
     });
 
-    it('should not validate mod of elem without block', function () {
-      assertFailure(s('__elem_mod_val'), 'bem');
+    it('should not validate mod of elem without block', function (done) {
+      assertSingleFailure(done, s('__elem_mod_val'), 'bem');
     });
 
-    it('should not validate boolean mod of elem without block', function () {
-      assertFailure(s('__elem_mod'), 'bem');
+    it(
+      'should not validate boolean mod of elem without block',
+      function (done) {
+        assertSingleFailure(done, s('__elem_mod'), 'bem');
+      }
+    );
+
+    it('should not validate nested elem', function (done) {
+      assertSingleFailure(done, s('block__elem1__elem2'), 'bem');
     });
 
-    it('should not validate nested elem', function () {
-      assertFailure(s('block__elem1__elem2'), 'bem');
+    it('should not validate multi mod', function (done) {
+      assertSingleFailure(done, s('block_mod_val__elem_mod_val'), 'bem');
     });
 
-    it('should not validate multi mod', function () {
-      assertFailure(s('block_mod_val__elem_mod_val'), 'bem');
-    });
-
-    it('should not validate block name with illegal literals', function () {
-      assertFailure(s('^_^'), 'bem');
-    });
+    it(
+      'should not validate block name with illegal literals',
+      function (done) {
+        assertSingleFailure(done, s('^_^'), 'bem');
+      }
+    );
   });
 });

--- a/test/definition.js
+++ b/test/definition.js
@@ -3,14 +3,14 @@ var assertSuccess = util.assertSuccess;
 
 describe('`@define` notation', function () {
   describe('CSS that lacks a definition', function () {
-    it('must be ignored', function () {
-      assertSuccess('.horse { color: pink; }');
+    it('must be ignored', function (done) {
+      assertSuccess(done, '.horse { color: pink; }');
     });
   });
 
   describe('CSS with a malformed definition', function () {
-    it('must be ignored', function () {
-      assertSuccess('/** @deforne Foo */ .Foo { color: pink; }')
+    it('must be ignored', function (done) {
+      assertSuccess(done, '/** @deforne Foo */ .Foo { color: pink; }')
     });
   });
 });

--- a/test/property-validation.js
+++ b/test/property-validation.js
@@ -1,36 +1,37 @@
 var util = require('./test-util');
 var assertSuccess = util.assertSuccess;
+var assertSingleFailure = util.assertSingleFailure;
 var assertFailure = util.assertFailure;
 var fixture = util.fixture;
 
 describe('property validation', function () {
   it(
     'accepts custom properties that begin with the component name',
-    function () {
-      assertSuccess(fixture('properties-valid'));
+    function (done) {
+      assertSuccess(done, fixture('properties-valid'));
     }
   );
 
   var invDef = '/** @define InvalidRootVars */';
 
-  it('accepts an empty root', function () {
-    assertSuccess(invDef + ':root {}');
+  it('accepts an empty root', function (done) {
+    assertSuccess(done, invDef + ':root {}');
   });
 
   it(
     'rejects custom properties that do not being with the component name',
-    function () {
-      assertFailure(
+    function (done) {
+      assertSingleFailure(done,
         invDef + ':root { --invalid-InvalidRootVars-color: green; }'
       );
     }
   );
 
-  it('rejects invalid root properties', function () {
-    assertFailure(invDef + ':root { color: green; }');
+  it('rejects invalid root declarations', function (done) {
+    assertSingleFailure(done, invDef + ':root { color: green; }');
   });
 
-  it('rejects root selectors grouped with other selectors', function () {
-    assertFailure(invDef + ':root, .InvalidRootSelector {}');
+  it('rejects root selectors grouped with other selectors', function (done) {
+    assertSingleFailure(done, invDef + ':root, .InvalidRootVars {}');
   });
 });

--- a/test/rule-validation.js
+++ b/test/rule-validation.js
@@ -1,13 +1,13 @@
 var util = require('./test-util');
 var assertSuccess = util.assertSuccess;
-var assertFailure = util.assertFailure;
+var assertSingleFailure = util.assertSingleFailure;
 
 describe('rule validation', function () {
-  it('allows `:root` not grouped with other selectors', function () {
-    assertSuccess('/** @define Foo */ :root {} .Foo {}');
+  it('allows `:root` not grouped with other selectors', function (done) {
+    assertSuccess(done, '/** @define Foo */ :root {} .Foo {}');
   });
 
-  it('errors if `:root` is grouped with other selectors', function () {
-    assertFailure('/** @define Foo */ :root, .Foo {}');
+  it('errors if `:root` is grouped with other selectors', function (done) {
+    assertSingleFailure(done, '/** @define Foo */ :root, .Foo {}');
   });
 });

--- a/test/selector-validation.js
+++ b/test/selector-validation.js
@@ -1,78 +1,128 @@
 var util = require('./test-util');
 var assertSuccess = util.assertSuccess;
-var assertFailure = util.assertFailure;
+var assertSingleFailure = util.assertSingleFailure;
 var selectorTester = util.selectorTester;
+var test = util.test;
 
 describe('selector validation', function () {
-  describe('with a custom `componentName` pattern', function () {
+  describe('with a custom `componentName` pattern /^[A-Z]+$/', function () {
     var p1 = { componentName: /^[A-Z]+$/, componentSelectors: function () { return /.*/; } };
-    var p2 = { componentName: /^[a-z]+1$/, componentSelectors: function () { return /.*/; } };
 
-    it('rejects invalid component names', function () {
-      assertFailure('/** @define Foo */', p1);
-      assertFailure('/** @define foo2 */', p2);
+    it('rejects component name Foo', function (done) {
+      assertSingleFailure(done, '/** @define Foo */', p1);
     });
 
-    it('accepts valid component names', function () {
-      assertSuccess('/** @define FOO */', p1);
-      assertSuccess('/** @define abc1 */', p2);
+    it('accepts component name FOO', function (done) {
+      assertSuccess(done, '/** @define FOO */', p1);
     });
   });
 
-  describe('with a single `componentSelectors` pattern', function () {
-    var patternA = {
-      componentSelectors: function (cmpt) {
-        return new RegExp('^\\.[a-z]+-' + cmpt + '(?:_[a-z]+)?$');
-      }
-    };
-    var s = selectorTester('/** @define Foo */');
+  describe('with a custom `componentName` pattern /^[a-z]+1$/', function () {
+    var p2 = { componentName: /^[a-z]+1$/, componentSelectors: function () { return /.*/; } };
 
-    it('accepts valid initial componentSelectors', function () {
-      assertSuccess(util.fixture('patternA-valid'), patternA);
+    it('rejects component name foo2', function (done) {
+      assertSingleFailure(done, '/** @define foo2 */', p2);
     });
 
-    it('rejects invalid initial componentSelectors', function () {
-      assertFailure(s('.Foo'), patternA);
-    });
-
-    it(
-      'rejects invalid initial componentSelectors in media queries',
-      function () {
-        assertFailure('/** @define Foo */ @media all { .Bar {} }');
-      }
-    );
-
-    it('ignores pseudo-selectors at the end of a sequence', function () {
-      assertSuccess(s('.f-Foo:hover'), patternA);
-      assertSuccess(s('.f-Foo::before'), patternA);
-      assertSuccess(s('.f-Foo:not(\'.is-open\')'), patternA);
-    });
-
-    it('accepts valid combined componentSelectors', function () {
-      assertSuccess(s('.f-Foo .f-Foo'), patternA);
-      assertSuccess(s('.f-Foo > .f-Foo'), patternA);
-    });
-
-    it('rejects invalid combined componentSelectors', function () {
-      assertFailure(s('.f-Foo > div'), patternA);
-      assertFailure(s('.f-Foo + #baz'), patternA);
-      assertFailure(s('.f-Foo~li>a.link#baz.foo'), patternA);
-    });
-
-    describe('in weak mode', function () {
-      var sWeak = selectorTester('/** @define Foo; weak */');
-
-      it('accepts any combined componentSelectors', function () {
-        assertSuccess(sWeak('.f-Foo .f-Foo'), patternA);
-        assertSuccess(sWeak('.f-Foo > div'), patternA);
-        assertSuccess(sWeak('.f-Foo + #baz'), patternA);
-        assertSuccess(sWeak('.f-Foo~li>a.link#baz.foo'), patternA);
-      });
+    it('accepts component name abc1', function (done) {
+      assertSuccess(done, '/** @define abc1 */', p2);
     });
   });
 
   describe(
-    'with different `initial` and `combined` selector patterns',
+    'with a single `componentSelectors` pattern ' +
+    'RegExp("^\\.[a-z]+-" + cmpt + "(?:_[a-z]+)?$")',
+    function () {
+      var patternA = {
+        componentSelectors: function (cmpt) {
+          return new RegExp('^\\.[a-z]+-' + cmpt + '(?:_[a-z]+)?$');
+        }
+      };
+      var s = selectorTester('/** @define Foo */');
+
+      it('accepts valid initial componentSelectors', function (done) {
+        var valid = util.fixture('patternA-valid');
+        assertSuccess(done, valid, patternA);
+      });
+
+      it('rejects initial componentSelector `.Foo`', function (done) {
+        assertSingleFailure(done, s('.Foo'), patternA);
+      });
+
+      it(
+        'rejects initial componentSelectors in media queries',
+        function (done) {
+          assertSingleFailure(
+            done,
+            '/** @define Foo */ @media all { .Bar {} }'
+          );
+        }
+      );
+
+      describe('with pseudo-selectors', function () {
+        it('ignores `:hover` at the end of a sequence', function (done) {
+          assertSuccess(done, s('.f-Foo:hover'), patternA);
+        });
+
+        it('ignores `::before` at the end of a sequence', function (done) {
+          assertSuccess(done, s('.f-Foo::before'), patternA);
+        });
+
+        it(
+          'ignores `:not(".is-open")` at the end of a sequence',
+          function (done) {
+            assertSuccess(done, s('.f-Foo:not(\'.is-open\')'), patternA);
+          }
+        );
+      });
+
+      describe('with combining', function () {
+        it('accepts `.f-Foo .f-Foo`', function (done) {
+          assertSuccess(done, s('.f-Foo .f-Foo'), patternA);
+        });
+
+        it('accepts `.f-Foo > .f-Foo`', function (done) {
+          assertSuccess(done, s('.f-Foo > .f-Foo'), patternA);
+        });
+
+        it('rejects `.f-Foo > div`', function (done) {
+          assertSingleFailure(done, s('.f-Foo > div'), patternA);
+        });
+
+        it('rejects `.f-Foo + #baz`', function (done) {
+          assertSingleFailure(done, s('.f-Foo + #baz'), patternA);
+        });
+
+        it('rejects `.f-Foo~li>a.link#baz.foo`', function (done) {
+          assertSingleFailure(done, s('.f-Foo~li>a.link#baz.foo'), patternA);
+        });
+      });
+
+      describe('in weak mode', function () {
+        var sWeak = selectorTester('/** @define Foo; weak */');
+
+        it('accepts `.f-Foo .f-Foo`', function (done) {
+          assertSuccess(done, sWeak('.f-Foo .f-Foo'), patternA);
+        });
+
+        it('accepts `.f-Foo > div`', function (done) {
+          assertSuccess(done, sWeak('.f-Foo > div'), patternA);
+        });
+
+        it('accepts `.f-Foo + #baz`', function (done) {
+          assertSuccess(done, sWeak('.f-Foo + #baz'), patternA);
+        });
+
+        it('accepts `.f-Foo~li>a.link#baz.foo`', function (done) {
+          assertSuccess(done, sWeak('.f-Foo~li>a.link#baz.foo'), patternA);
+        });
+      });
+    }
+  );
+
+  describe(
+    'with different `initial` ("^\\." + cmpt + "(?:-[a-z]+)?$") and ' +
+    '`combined` ("^\\.c-" + cmpt + "(?:-[a-z]+)?$") selector patterns',
     function () {
     var patternB = {
       componentSelectors: {
@@ -86,26 +136,51 @@ describe('selector validation', function () {
     };
     var s = selectorTester('/** @define Foo */');
 
-    it('accepts valid combined componentSelectors', function () {
-      assertSuccess(s('.Foo .c-Foo'), patternB);
-      assertSuccess(s('.Foo-bar > .c-Foo-bar'), patternB);
-      assertSuccess(s('.Foo-bar>.c-Foo-bar'), patternB);
+    it('accepts `.Foo .c-Foo`', function (done) {
+      assertSuccess(done, s('.Foo .c-Foo'), patternB);
     });
 
-    it('rejects invalid combined componentSelectors', function () {
-      assertFailure(s('.Foo .cc-Foo'), patternB);
-      assertFailure(s('.Foo > .Foo-F'), patternB);
+    it('accepts `.Foo-bar > .c-Foo-bar`', function (done) {
+      assertSuccess(done, s('.Foo-bar > .c-Foo-bar'), patternB);
+    });
+
+    it('accepts `.Foo-bar>.c-Foo-bar`', function (done) {
+      assertSuccess(done, s('.Foo-bar>.c-Foo-bar'), patternB);
+    });
+
+    it('rejects `.Foo .cc-Foo`', function (done) {
+      assertSingleFailure(done, s('.Foo .cc-Foo'), patternB);
+    });
+
+    it('rejects `.Foo > .Foo-F`', function (done) {
+      assertSingleFailure(done, s('.Foo > .Foo-F'), patternB);
     });
 
     describe('in weak mode', function () {
       var sWeak = selectorTester('/** @define Foo; weak*/');
 
-      it('accepts any combined componentSelectors', function () {
-        assertSuccess(sWeak('.Foo .c-Foo'), patternB);
-        assertSuccess(sWeak('.Foo .Foo'), patternB);
-        assertSuccess(sWeak('.Foo > div'), patternB);
-        assertSuccess(sWeak('.Foo + #baz'), patternB);
-        assertSuccess(sWeak('.Foo~li>a.link#baz.foo'), patternB);
+      describe('in weak mode', function () {
+        var sWeak = selectorTester('/** @define Foo; weak*/');
+
+        it('accepts `.Foo .c-Foo`', function (done) {
+          assertSuccess(done, sWeak('.Foo .c-Foo'), patternB);
+        });
+
+        it('accepts `.Foo .Foo`', function (done) {
+          assertSuccess(done, sWeak('.Foo .Foo'), patternB);
+        });
+
+        it('accepts `.Foo > div`', function (done) {
+          assertSuccess(done, sWeak('.Foo > div'), patternB);
+        });
+
+        it('accepts `.Foo + #baz`', function (done) {
+          assertSuccess(done, sWeak('.Foo + #baz'), patternB);
+        });
+
+        it('accepts `.Foo~li>a.link#baz.foo`', function (done) {
+          assertSuccess(done, sWeak('.Foo~li>a.link#baz.foo'), patternB);
+        });
       });
     });
   });
@@ -116,14 +191,20 @@ describe('selector validation', function () {
     };
     var s = selectorTester('/** @define utilities */');
 
-    it('accepts valid utilitySelectors', function () {
-      assertSuccess(s('.UTIL-foo'), patternC);
-      assertSuccess(s('.UTIL-foobarbaz'), patternC);
+    it('accepts `.UTIL-foo`', function (done) {
+      assertSuccess(done, s('.UTIL-foo'), patternC);
     });
 
-    it('rejects invalid utilitySelectors', function () {
-      assertFailure(s('.Foo'), patternC);
-      assertFailure(s('.U-foo'), patternC);
+    it('accepts `.UTIL-foobarbaz`', function (done) {
+      assertSuccess(done, s('.UTIL-foobarbaz'), patternC);
+    });
+
+    it('rejects `.Foo`', function (done) {
+      assertSingleFailure(done, s('.Foo'), patternC);
+    });
+
+    it('rejects `.U-foo`', function (done) {
+      assertSingleFailure(done, s('.U-foo'), patternC);
     });
   });
 });

--- a/test/suit-pattern.js
+++ b/test/suit-pattern.js
@@ -1,46 +1,77 @@
 var util = require('./test-util');
 var assertSuccess = util.assertSuccess;
-var assertFailure = util.assertFailure;
+var assertSingleFailure = util.assertSingleFailure;
 var selectorTester = util.selectorTester;
 var fixture = util.fixture;
 
 describe('using SUIT pattern (default)', function () {
-  it('accepts valid component classes', function () {
-    assertSuccess(fixture('suit-valid'));
+  it('accepts valid component classes', function (done) {
+    assertSuccess(done, fixture('suit-valid'));
   });
 
   var s = selectorTester('/** @define Foo */');
 
-  it('selectors must begin with the component name', function () {
-    assertFailure(s('.potentialFalseMatch'));
-    assertFailure(s('div'));
-    assertFailure(s('.Error'));
+  describe('selectors must begin with the component name', function () {
+    it('rejects `.potentialFalseMatch`', function (done) {
+      assertSingleFailure(done, s('.potentialFalseMatch'));
+    });
+
+    it('rejects `div`', function (done) {
+      assertSingleFailure(done, s('div'));
+    });
+
+    it('rejects `.Error`', function (done) {
+      assertSingleFailure(done, s('.Error'));
+    });
   });
 
-  it('understands namespaces', function () {
-    assertSuccess(s('.ns-Foo'), 'suit', { namespace: 'ns' });
-    assertFailure(s('.Foo'), 'suit', { namespace: 'ns' });
-    assertSuccess(s('.Ho04__d-Foo'), 'suit', { namespace: 'Ho04__d' });
+  describe('understands namespaces', function () {
+    it('and with namespace `ns` accepts `ns-Foo`', function (done) {
+      assertSuccess(done, s('.ns-Foo'), 'suit', { namespace: 'ns' });
+    });
+
+    it('and with namespace `Ho04__d` accepts `Ho04__d-Foo`', function (done) {
+      assertSuccess(done, s('.Ho04__d-Foo'), 'suit', { namespace: 'Ho04__d' });
+    });
+
+    it('and with namespace `ns` rejects `.Foo`', function (done) {
+      assertSingleFailure(done, s('.Foo'), 'suit', { namespace: 'ns' });
+    });
   });
 
-  it('rejects invalid combined classes', function () {
+  it('rejects invalid combined classes', function (done) {
     var sInvalid = selectorTester('/** @define StrictInvalidSelector */');
-    assertFailure(sInvalid('.StrictInvalidSelector .Another'));
+    assertSingleFailure(done, sInvalid('.StrictInvalidSelector .Another'));
   });
 
-  it('deals fairly with utility classes', function () {
+  describe('deals fairly with utility classes', function () {
     var sUtil = util.selectorTester('/** @define utilities */');
-    assertSuccess(sUtil('.u-foo'));
-    assertSuccess(sUtil('.u-fooBar'));
-    assertSuccess(sUtil('.u-fooBar17'));
-    assertFailure(sUtil('.Foo'));
-    assertFailure(sUtil('.u-Foo'));
+
+    it('accepts `u-foo`', function (done) {
+      assertSuccess(done, sUtil('.u-foo'));
+    });
+
+    it('accepts `u-fooBar`', function (done) {
+      assertSuccess(done, sUtil('.u-fooBar'));
+    });
+
+    it('accepts `u-fooBar17`', function (done) {
+      assertSuccess(done, sUtil('.u-fooBar17'));
+    });
+
+    it('rejects `.Foo`', function (done) {
+      assertSingleFailure(done, sUtil('.Foo'));
+    });
+
+    it('rejects `.u-Foo`', function (done) {
+      assertSingleFailure(done, sUtil('.u-Foo'));
+    });
   });
 
   describe('in weak mode', function () {
-    it('accepts arbitrary combined classes', function () {
+    it('accepts arbitrary combined classes', function (done) {
       var sWeak = selectorTester('/** @define ValidRules; weak */');
-      assertSuccess(sWeak('.ValidRules .Another'));
+      assertSuccess(done, sWeak('.ValidRules .Another'));
     });
   });
 });


### PR DESCRIPTION
Address #32. Upgrades to PostCSS 4.1, which involves
- dealing with async
- using the warnings API

Most of the work was in rewriting tests so they worked with async. Then changing error throwing to warning registering.

I made the plugin [postcss-log-warnings](https://github.com/davidtheclark/postcss-log-warnings) so that this plugin could just register warnings and then that one would log them to the console. Take a look at it and see what you think.

Here's a simple example of using the log-warnings plugin. You can make a JS file with this content and put it in the base directory of bem-linter and run it to see what the console warnings look like.

```js
var postcss = require('postcss');
var logWarnings = require('postcss-log-warnings');
var linter = require('./index');
var fs = require('fs');

var css = fs.readFileSync('test/fixtures/bem-valid.css', 'utf8');

postcss()
  .use(linter())
  .use(logWarnings())
  .process(css, { from: 'test/fixtures/bem-valid.css' })
  .then(function(result) {
    console.log('finished');
  });

```

I also updated a couple of dependencies.