### PR TITLE
Strip pseudos from utility selectors before check; fixes #45

### DIFF
--- a/lib/is-valid-selector.js
+++ b/lib/is-valid-selector.js
@@ -1,6 +1,12 @@
 'use strict';
 
 /**
+ * Module dependencies
+ */
+
+var listSequences = require('./listSequences');
+
+/**
  * Module exports
  */
 
@@ -22,14 +28,14 @@ module.exports = isValidSelector;
  *   The returned regexp will be used to test all selector sequences.
  * - An object that has the following properties:
  *   - initial: A function that accepts a component name and returns
- *   	 a regexp. This regexp will be used to test selector sequences
- *   	 at the beginning of the selector (before any combinators).
- *   	 If no combined property is included, this function will also
- *   	 be used to test sequences after combinators.
+ *     a regexp. This regexp will be used to test selector sequences
+ *     at the beginning of the selector (before any combinators).
+ *     If no combined property is included, this function will also
+ *     be used to test sequences after combinators.
  *   - combined: A function that accepts a component name and returns
- *   	 a regexp. This regexp will be used to test selector sequences
- *   	 that come after combinators, if they do not already
- *   	 match the initial pattern.
+ *     a regexp. This regexp will be used to test selector sequences
+ *     that come after combinators, if they do not already
+ *     match the initial pattern.
  */
 
 /**
@@ -65,28 +71,4 @@ function isValidSelector(selector, componentName, weakMode, pattern, opts) {
     return initialPattern.test(combinedSequence) ||
     combinedPattern.test(combinedSequence);
   });
-}
-
-/**
- * Extract an array of selector sequences from a selector string ---
- * all the sequences that were combined via combinators.
- *
- * CSS combinators are whitespace, >, +, ~
- * (cf. http://www.w3.org/TR/css3-selectors/#selector-syntax)
- *
- * Ignore pseudo-selectors ... by presuming they come at the end of the
- * sequence and cutting them off from the string that gets checked.
- *
- * @param {String} selector
- * @returns {String[]}
- */
-function listSequences(selector) {
-  return selector
-    .split(/[\s>+~]/)
-    .filter(function (s) {
-      return s !== '';
-    })
-    .map(function (s) {
-      return s.split(':')[0];
-    });
 }

--- a/lib/is-valid-utility.js
+++ b/lib/is-valid-utility.js
@@ -1,6 +1,12 @@
 'use strict';
 
 /**
+ * Module dependencies
+ */
+
+var listSequences = require('./listSequences');
+
+/**
  * Module exports
  */
 
@@ -12,5 +18,8 @@ module.exports = isValidUtility;
  * @returns {Boolean}
  */
 function isValidUtility(selector, pattern) {
-  return pattern.test(selector);
+  var sequences = listSequences(selector);
+  return sequences.every(function (sequence) {
+    return pattern.test(sequence);
+  });
 }

--- a/lib/listSequences.js
+++ b/lib/listSequences.js
@@ -1,0 +1,25 @@
+module.exports = listSequences;
+
+/**
+ * Extract an array of selector sequences from a selector string ---
+ * all the sequences that were combined via combinators.
+ *
+ * CSS combinators are whitespace, >, +, ~
+ * (cf. http://www.w3.org/TR/css3-selectors/#selector-syntax)
+ *
+ * Ignore pseudo-selectors ... by presuming they come at the end of the
+ * sequence and cutting them off from the string that gets checked.
+ *
+ * @param {String} selector
+ * @returns {String[]}
+ */
+function listSequences(selector) {
+  return selector
+    .split(/[\s>+~]/)
+    .filter(function (s) {
+      return s !== '';
+    })
+    .map(function (s) {
+      return s.split(':')[0];
+    });
+}

--- a/test/selector-validation.js
+++ b/test/selector-validation.js
@@ -200,6 +200,14 @@ describe('selector validation', function () {
       assertSuccess(done, s('.UTIL-foobarbaz'), patternC);
     });
 
+    it('accepts `.UTIL-foo:hover`', function (done) {
+      assertSuccess(done, s('.UTIL-foo:hover'), patternC);
+    });
+
+    it('accepts `.UTIL-foo::before`', function (done) {
+      assertSuccess(done, s('.UTIL-foo::before'), patternC);
+    });
+
     it('rejects `.Foo`', function (done) {
       assertSingleFailure(done, s('.Foo'), patternC);
     });


### PR DESCRIPTION
Addresses oversight that made pseudos work for component selectors but not utility selectors (#45).

Also I guess fixes some whitespace.